### PR TITLE
Add all classes to Mixr namespace

### DIFF
--- a/fader.cpp
+++ b/fader.cpp
@@ -2,6 +2,8 @@
 #include <math.h>
 #include "fader.h"
 
+namespace Mixr {
+
 void Fader::connectFrom(QString jack_port) {
 
     jack_port_disconnect(client, input_port_1);
@@ -108,3 +110,5 @@ Fader::~Fader()
     jack_port_unregister(client, output_port_2);
     jack_client_close(client);
 }
+
+} // namespace Mixr

--- a/fader.h
+++ b/fader.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <jack/jack.h>
 
+namespace Mixr {
 
 class Fader : public QObject
 {
@@ -53,5 +54,7 @@ private slots:
     void setPortVolumes();
 
 };
+
+} // namespace Mixr
 
 #endif // FADER_H

--- a/main.cpp
+++ b/main.cpp
@@ -23,12 +23,12 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    Fader m_Fader_01(client, "01");
-    Fader m_Fader_02(client, "02");
-    Fader m_Fader_03(client, "03");
-    Fader m_Fader_04(client, "04");
+    Mixr::Fader m_Fader_01(client, "01");
+    Mixr::Fader m_Fader_02(client, "02");
+    Mixr::Fader m_Fader_03(client, "03");
+    Mixr::Fader m_Fader_04(client, "04");
 
-    Mixer m_Mixer(client);
+    Mixr::Mixer m_Mixer(client);
     m_Mixer.fader_01 = &m_Fader_01;
     m_Mixer.fader_02 = &m_Fader_02;
     m_Mixer.fader_03 = &m_Fader_03;
@@ -39,7 +39,7 @@ int main(int argc, char *argv[]) {
     engine.rootContext()->setContextProperty("c_fader_03", m_Mixer.fader_03);
     engine.rootContext()->setContextProperty("c_fader_04", m_Mixer.fader_04);
 
-    Transport m_transport(client);
+    Mixr::Transport m_transport(client);
     engine.rootContext()->setContextProperty("c_transport", &m_transport);
 
 

--- a/mixer.cpp
+++ b/mixer.cpp
@@ -3,6 +3,8 @@
 #include <jack/jack.h>
 #include <jack/transport.h>
 
+namespace Mixr {
+
 //static void processs (jack_transport_state_t state, jack_nframes_t nframes, jack_position_t *pos, int, void *arg) {}
 static int processFader (jack_nframes_t nframes, void *arg)
 {
@@ -63,4 +65,4 @@ Mixer::Mixer(jack_client_t *j_client)
 
 }
 
-
+} // namespace Mixr

--- a/mixer.h
+++ b/mixer.h
@@ -4,6 +4,8 @@
 #include <jack/jack.h>
 #include "fader.h"
 
+namespace Mixr {
+
 class Mixer
 {
 public:
@@ -20,5 +22,7 @@ public:
 
     static int process (jack_nframes_t nframes, void *arg);
 };
+
+} // namespace Mixr
 
 #endif // MIXER_H

--- a/transport.cpp
+++ b/transport.cpp
@@ -4,6 +4,8 @@
 #include <jack/jack.h>
 #include <jack/transport.h>
 
+namespace Mixr {
+
 Transport::Transport(jack_client_t *client) { this->client = client; }
 
 void Transport::rewind() { jack_transport_stop (client); jack_transport_locate(client, 0); }
@@ -30,3 +32,5 @@ QString Transport::getTime() {
 
     return qTime.toString("HH:mm:ss.zzz");
 }
+
+} // namespace Mixr

--- a/transport.h
+++ b/transport.h
@@ -5,6 +5,8 @@
 #include <jack/jack.h>
 #include <jack/transport.h>
 
+namespace Mixr {
+
 class Transport : public QObject
 {
     Q_OBJECT
@@ -25,5 +27,7 @@ public slots:
     QString getBBT();
 
 };
+
+} // namespace Mixr
 
 #endif // TRANSPORT_H


### PR DESCRIPTION
This pull request is related to issue #8. By adding all the project's symbols into the Mixr namespace we guarantee that there will be no name clashes in the global scope (good C++ practice).